### PR TITLE
Update assets-plugin-chain-utils image version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,7 @@ runs:
       run: /app/plugin-gosec-scanner -mode single
 
     - name: Complete execution plan
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:eda1f86aa17218e8779fae9ff1ac9161b708d07e
+      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:latest
       id: process-outputs
       with:
           entrypoint: assets-plugin-chain-utils

--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ runs:
       run: /app/plugin-gosec-scanner -mode single
 
     - name: Complete execution plan
-      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:700b11324a4bf55ebdbba5e32ffbb5f58f1c9287
+      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:b3e498d665c5fbd6eb4250cafcf849c03d3ad538
       id: process-outputs
       with:
           entrypoint: assets-plugin-chain-utils

--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ runs:
       run: /app/plugin-gosec-scanner -mode single
 
     - name: Complete execution plan
-      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:b3e498d665c5fbd6eb4250cafcf849c03d3ad538
+      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:d0ed9fe13989e415f3c06ca054386e5b8eb482ea
       id: process-outputs
       with:
           entrypoint: assets-plugin-chain-utils

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
   using: composite
   steps:
     - name: Generate sha and ref 
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:eda1f86aa17218e8779fae9ff1ac9161b708d07e
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:d6f8da3c4668c10a421230d2ed409f5c0b28a050
       with:
         entrypoint: assets-plugin-chain-utils
         args: get-commit-info
@@ -48,7 +48,7 @@ runs:
          INPUT_WORKSPACE_DIR: ${{ inputs.workspace-dir }}
 
     - name: Generate reference files 
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:eda1f86aa17218e8779fae9ff1ac9161b708d07e
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:d6f8da3c4668c10a421230d2ed409f5c0b28a050
       with:
           entrypoint: assets-plugin-chain-utils
           args: generate-references --asset-type "CODE"

--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ runs:
       run: /app/plugin-gosec-scanner -mode single
 
     - name: Complete execution plan
-      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:ff4d75579893f27f866232d22ed75aa699c0a7aa
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:d6f8da3c4668c10a421230d2ed409f5c0b28a050
       id: process-outputs
       with:
           entrypoint: assets-plugin-chain-utils

--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,7 @@ runs:
       run: /app/plugin-gosec-scanner -mode single
 
     - name: Complete execution plan
-      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:latest
+      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:65ef2f87f5690a35773f7d73f3ee9d2fdf0933b1
       id: process-outputs
       with:
           entrypoint: assets-plugin-chain-utils

--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ runs:
       run: /app/plugin-gosec-scanner -mode single
 
     - name: Complete execution plan
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:ff4d75579893f27f866232d22ed75aa699c0a7aa
+      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:ff4d75579893f27f866232d22ed75aa699c0a7aa
       id: process-outputs
       with:
           entrypoint: assets-plugin-chain-utils

--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ runs:
       run: /app/plugin-gosec-scanner -mode single
 
     - name: Complete execution plan
-      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:d0ed9fe13989e415f3c06ca054386e5b8eb482ea
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:ff4d75579893f27f866232d22ed75aa699c0a7aa
       id: process-outputs
       with:
           entrypoint: assets-plugin-chain-utils

--- a/action.yml
+++ b/action.yml
@@ -68,6 +68,7 @@ runs:
 
     - name: Run gosec compliance plugin
       uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-gosec-scanner:92d7a0b05998b0bb4164d8521c8716112a41b7a7
+      continue-on-error: true
       env:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}

--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,7 @@ runs:
       run: /app/plugin-gosec-scanner -mode single
 
     - name: Complete execution plan
-      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:65ef2f87f5690a35773f7d73f3ee9d2fdf0933b1
+      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:700b11324a4bf55ebdbba5e32ffbb5f58f1c9287
       id: process-outputs
       with:
           entrypoint: assets-plugin-chain-utils


### PR DESCRIPTION

* Added `continue-on-error: true` to the "Run gosec compliance plugin" step, allowing the workflow to proceed even if this step fails.
* Updated the Docker image version for the "Complete execution plan" step, switching to a newer version of the `assets-plugin-chain-utils` plugin.